### PR TITLE
add output format HTML

### DIFF
--- a/src/pdf_ocr/cli.py
+++ b/src/pdf_ocr/cli.py
@@ -179,6 +179,7 @@ def main() -> None:
     try:
         asyncio.run(run(args, console))
     except Exception:
+        raise
         sys.exit(1)
 
 

--- a/src/pdf_ocr/core/pdf.py
+++ b/src/pdf_ocr/core/pdf.py
@@ -11,6 +11,7 @@ a PDF wrap step first. AVIF support is provided natively by Pillow ≥
 import base64
 import io
 from pathlib import Path
+import os
 
 import fitz  # PyMuPDF
 from PIL import Image, ImageSequence
@@ -111,6 +112,15 @@ class PDFHandler:
             dpi: Rasterization DPI for PDF-sourced backgrounds (ignored for
                 image inputs — they're used at native resolution).
         """
+        output_ext = os.path.splitext(output_pdf_path)[1].lower()
+        print(f"output_ext: {output_ext!r}")
+        if output_ext == ".html":
+            return self._embed_structured_text_html(
+                input_pdf_path,
+                output_pdf_path,
+                pages_data,
+                dpi,
+            )
         if _is_image_path(input_pdf_path):
             self._embed_from_image_input(input_pdf_path, output_pdf_path, pages_data)
             return
@@ -327,3 +337,323 @@ class PDFHandler:
             render_mode=3, color=(0, 0, 0),
             morph=morph,
         )
+
+
+    def _embed_structured_text_html(
+        self,
+        input_pdf_path: str,
+        output_html_path: str,
+        pages_data: dict[int, list[tuple[list[float], str]]],
+        dpi: int = 200,
+    ) -> None:
+        """
+        Build an HTML document: rasterize each page as a background
+        image and overlay invisible text positioned to match the source layout.
+
+        Accepts either a PDF or a raw image (JPEG/PNG/TIFF/BMP/WebP/AVIF)
+        as input. Image inputs are converted to a 1-page-per-frame PDF —
+        no rasterization-to-PDF-to-rasterization round trip required.
+
+        Args:
+            input_pdf_path: Path to the source PDF or image file.
+            output_html_path: Where to write the HTML document.
+            pages_data: {page_num: [([nx0, ny0, nx1, ny1], text), ...]} with
+                normalized (0..1) box coordinates.
+            dpi: Rasterization DPI for PDF-sourced backgrounds (ignored for
+                image inputs — they're used at native resolution).
+        """
+        if _is_image_path(input_pdf_path):
+            self._embed_from_image_input_html(input_pdf_path, output_html_path, pages_data)
+            return
+
+        raise NotImplementedError("_is_image_path(input_pdf_path) == False")
+
+
+    def _embed_from_image_input_html(
+        self,
+        image_path: str,
+        output_html_path: str,
+        pages_data: dict,
+    ) -> None:
+        """Build an HTML document directly from an image (single- or multi-frame)."""
+        new_doc = open(output_html_path, "w", encoding="utf8")
+
+        new_doc.write('<!doctype html>\n')
+        new_doc.write('<html>\n')
+        new_doc.write('<head>\n')
+        new_doc.write('<style>\n')
+        new_doc.write('div.page {\n')
+        new_doc.write('  outline: solid 1px gray;\n')
+        new_doc.write('}\n')
+        new_doc.write('span.line {\n')
+        new_doc.write('  position: absolute;\n')
+        new_doc.write('  color: transparent;\n')
+        new_doc.write('  white-space: nowrap;\n')
+        # font aspect: 0.6
+        new_doc.write('  font-family: monospace;\n')
+        new_doc.write('}\n')
+        new_doc.write('</style>\n')
+        new_doc.write('</head>\n')
+        new_doc.write('<body>\n')
+
+        try:
+            with Image.open(image_path) as src:
+                if src.n_frames == 0:
+                    raise ValueError(f"image has no frames: {image_path!r}")
+                # if src.n_frames > 1:
+                #     raise NotImplementedError("src.n_frames > 1")
+                for page_num, frame in enumerate(ImageSequence.Iterator(src)):
+                    # one image, one page
+                    new_page = new_doc
+                    # width, height = float(frame.width), float(frame.height) # why float?
+                    width, height = frame.width, frame.height
+                    if src.n_frames == 1:
+                        # single-frame image
+                        # use path to image file
+                        img_url = os.path.relpath(image_path, os.path.dirname(output_html_path))
+                    else:
+                        # multi-frame image
+                        # inline frame as data URL
+                        img = frame.convert("RGB") # TODO why not keep grayscale
+                        buf = io.BytesIO()
+                        img.save(buf, format="JPEG", quality=85)
+                        img_url = (
+                            "data:base64," +
+                            base64.b64encode(buf.getvalue()).decode("ascii")
+                        )
+                        del img
+                    page_style = (
+                        f"background-image:url({img_url!r});" +
+                        f"background-repeat:no-repeat;" +
+                        f"width:{width}px;" +
+                        f"height:{height}px;" +
+                        ""
+                    )
+                    del img_url
+                    new_doc.write(f'<div class="page" style="{page_style}">\n')
+                    del page_style
+                    for rect_coords, text in pages_data.get(page_num, []):
+                        self._draw_invisible_text_html(
+                            new_page, rect_coords, text, width, height
+                        )
+                    new_doc.write(f'</div>\n')
+                return
+                # TODO remove
+                for page_num, frame in enumerate(ImageSequence.Iterator(src)):
+                    img = frame.convert("RGB")
+                    # One PDF point = 1/72 inch. Assume image is 72 DPI so
+                    # pixel count equals page size in points. Concrete value
+                    # doesn't matter — all coords are normalized.
+                    width, height = float(img.width), float(img.height)
+
+                    buf = io.BytesIO()
+                    img.save(buf, format="JPEG", quality=85)
+                    img_data = buf.getvalue()
+
+                    new_page = new_doc.new_page(width=width, height=height)
+                    new_page.insert_image(new_page.rect, stream=img_data)
+
+                    for rect_coords, text in pages_data.get(page_num, []):
+                        self._draw_invisible_text(
+                            new_page, rect_coords, text, width, height
+                        )
+            # new_doc.save(output_pdf_path)
+            new_doc.write(f'</body>\n')
+            new_doc.write(f'</html>\n')
+        finally:
+            new_doc.close()
+
+
+    @staticmethod
+    def _draw_invisible_text_html(page, rect_coords, text, page_width, page_height):
+        text = (text or "").strip()
+        if not text:
+            return  # empty box — nothing to embed
+
+        nx0, ny0, nx1, ny1 = rect_coords
+
+        # Detect the aligner's full-page fallback by bbox (covers the
+        # whole normalized page, [0,0,1,1]) rather than by the presence
+        # of "\n" in text. A grounded VLM that emits multi-line content
+        # for a real bbox must NOT be redirected to the full-page
+        # fallback rect — that would shift the text to the page top and
+        # clobber other bboxes' search positions, surfacing as
+        # "following lines moved up" in the rendered output.
+        is_full_page_fallback = (
+            nx0 <= 0.001 and ny0 <= 0.001
+            and nx1 >= 0.999 and ny1 >= 0.999
+            and "\n" in text
+        )
+        if is_full_page_fallback:
+            fallback_rect = (
+                10,
+                10,
+                page_width - 10,
+                page_height - 10
+            )
+            _page_insert_textbox_html(
+                page,
+                fallback_rect,
+                text,
+                # fontsize=6,
+                # fontname="helv",
+                # render_mode=3,
+                # color=(0, 0, 0),
+                # align=0,
+            )
+            return
+
+        # A real bbox with multi-line content: split by line and recurse
+        # to place each line at its own vertical sub-slice of the bbox.
+        # Handles grounded-VLM outputs that joined visual lines into one
+        # element with an embedded "\n" — search/selection still land at
+        # the right y position instead of being shifted off-page.
+        lines = [ln.strip() for ln in text.split("\n") if ln.strip()]
+        slice_h = (ny1 - ny0) / len(lines)
+        for i, line in enumerate(lines):
+            line_rect = (
+                nx0,
+                ny0 + i * slice_h,
+                nx1,
+                ny0 + (i + 1) * slice_h
+            )
+            line_rect = (
+                page_width * (nx0),
+                page_height * (ny0 + i * slice_h),
+                page_width * (nx1),
+                page_height * (ny0 + (i + 1) * slice_h)
+            )
+            _page_insert_textbox_html(
+                page,
+                line_rect,
+                line,
+            )
+            # PDFHandler._draw_invisible_text(
+            #     page,
+            #     line_rect,
+            #     line,
+            #     page_width,
+            #     page_height,
+            # )
+        return
+        # TODO remove
+        text = lines[0] if lines else text  # only one non-empty line
+
+        pdf_rect = fitz.Rect(
+            nx0 * page_width,
+            ny0 * page_height,
+            nx1 * page_width,
+            ny1 * page_height,
+        )
+
+        box_width = pdf_rect.width
+        box_height = pdf_rect.height
+        if box_width <= 0 or box_height <= 0:
+            return
+
+        font = fitz.Font("helv")
+
+        # Size so the full glyph extent (ascender - descender in em-units)
+        # fits exactly inside the box height. For Helvetica this works out
+        # to ~box_height/1.374 ≈ box_height * 0.728 — tighter than the old
+        # 0.85 constant, and eliminates the ascender overshoot we used to
+        # tolerate at the top edge.
+        ascender = getattr(font, "ascender", 1.075)  # Helvetica fallback
+        descender = getattr(font, "descender", -0.299)
+        extent_em = max(0.01, ascender - descender)  # descender is negative
+        fontsize = max(3.0, min(72.0, box_height / extent_em))
+
+        # Multi-line bbox detection: Surya occasionally groups visually
+        # adjacent handwritten lines into one detection (e.g. "schwache
+        # Grenzen / im Kopf"). The DP then matches the LLM's joined
+        # string to that one tall bbox, and the embed would render the
+        # whole phrase at one y (the bottom of the bbox), leaving the
+        # upper visual line empty in the searchable text layer.
+        #
+        # Heuristic: distinguish a multi-line region from a single tall-
+        # but-still-one-line bbox. Aspect alone confuses handwritten
+        # "Typen 23" (one line, aspect ≈ 0.28 due to padding around the
+        # glyphs) with a real two-line region (aspect ≈ 0.27-0.35).
+        # Combine signals — the bbox must be tall in the absolute sense
+        # (norm height > 7% of page) AND have multi-line aspect ratio.
+        # Single visual lines on Letter-size pages take ~4-6% of page
+        # height even with generous padding, so the combined gate
+        # catches the 2-line case without over-splitting padded single
+        # lines.
+        words = text.split()
+        norm_height = ny1 - ny0
+        aspect = box_height / max(0.01, box_width)
+        if norm_height > 0.07 and aspect > 0.20 and len(words) >= 2:
+            n_lines = 3 if norm_height > 0.13 else 2
+            n_lines = min(n_lines, len(words))
+            slice_h = (ny1 - ny0) / n_lines
+            for i in range(n_lines):
+                start = round(i * len(words) / n_lines)
+                end = round((i + 1) * len(words) / n_lines)
+                line_text = " ".join(words[start:end])
+                if not line_text:
+                    continue
+                PDFHandler._draw_invisible_text(
+                    page,
+                    [nx0, ny0 + i * slice_h, nx1, ny0 + (i + 1) * slice_h],
+                    line_text, page_width, page_height,
+                )
+            return
+
+        natural_width = font.text_length(text, fontsize=fontsize)
+        if natural_width <= 0:
+            return  # nothing measurable to draw (e.g. all-whitespace)
+
+        # Horizontal scale so extracted word bbox spans the full box width
+        # (minus a hairline margin so we don't butt up against neighbours).
+        # scale_x > 1 stretches; scale_x < 1 compresses — both correctly
+        # size the word's bounding box, which is what selection uses.
+        target_width = max(1.0, box_width * 0.98)
+        scale_x = target_width / natural_width
+
+        # Place baseline at box bottom, shifted up by the descender so tails
+        # of "g"/"p"/"y" sit inside the box and the glyph tops land on the
+        # box top (since ascender*fontsize + |descender|*fontsize = box_height
+        # by construction).
+        baseline = fitz.Point(pdf_rect.x0, pdf_rect.y1 + descender * fontsize)
+
+        # Morph pivot = baseline. Matrix scales x around that pivot so
+        # the text's starting x stays at pdf_rect.x0 and the end x lands
+        # at pdf_rect.x0 + target_width.
+        morph = (baseline, fitz.Matrix(scale_x, 1.0))
+        page.insert_text(
+            baseline, text,
+            fontsize=fontsize, fontname="helv",
+            render_mode=3, color=(0, 0, 0),
+            morph=morph,
+        )
+
+
+
+
+def _page_insert_textbox_html(
+        page,
+        rect,
+        text,
+        # fontsize=6,
+        # fontname="helv",
+        # render_mode=3,
+        # color=(0, 0, 0),
+        # align=0,
+    ):
+    x0, y0, x1, y1 = rect
+    width = x1 - x0
+    height = y1 - y0
+    font_rel_width = 0.6 # monospace # width / height
+    char_width = width / len(text)
+    char_height = char_width / font_rel_width
+    font_size = min(height, char_height)
+    line_style = (
+        f"left:{x0}px;" +
+        f"top:{y0}px;" +
+        f"width:{width}px;" +
+        f"height:{height}px;" +
+        f"font-size:{font_size}px;" +
+        ""
+    )
+    page.write(f'<span class="line" style="{line_style}">{text}</span>\n')

--- a/src/pdf_ocr/core/pdf.py
+++ b/src/pdf_ocr/core/pdf.py
@@ -426,7 +426,7 @@ class PDFHandler:
                         buf = io.BytesIO()
                         img.save(buf, format="JPEG", quality=85)
                         img_url = (
-                            "data:base64," +
+                            "data:image/jpeg;base64," +
                             base64.b64encode(buf.getvalue()).decode("ascii")
                         )
                         del img

--- a/src/pdf_ocr/core/pdf.py
+++ b/src/pdf_ocr/core/pdf.py
@@ -659,6 +659,7 @@ def _page_insert_textbox_html(
         text,
         attrs=None,
         use_letter_spacing=False,
+        use_full_height=False,
         # fontsize=6,
         # fontname="helv",
         # render_mode=3,
@@ -674,7 +675,14 @@ def _page_insert_textbox_html(
         font_size = height
         raw_width = len(text) * font_size * font_rel_width
         letter_spacing = (width - raw_width) / len(text)
+    elif use_full_height:
+        # font-size can be too large
+        # which makes the text overflow the bbox
+        font_size = height
     else:
+        # width can be too small
+        # so scaling can make the text hard to read
+        # but still better than overflow
         char_width = width / len(text)
         char_height = char_width / font_rel_width
         font_size = min(height, char_height)
@@ -696,4 +704,4 @@ def _page_insert_textbox_html(
     for key, val in attrs.items():
         val_str = json.dumps(val, separators=(',', ':'))
         attrs_str += f' {key}={val_str!r}'
-    page.write(f'<span class="line" style="{line_style}"{attrs_str}>{text}</span>\n')
+    page.write(f'<span class="line" style="{line_style}"{attrs_str}\n>{text}</span>\n')

--- a/src/pdf_ocr/core/pdf.py
+++ b/src/pdf_ocr/core/pdf.py
@@ -12,6 +12,7 @@ import base64
 import io
 from pathlib import Path
 import os
+import json
 
 import fitz  # PyMuPDF
 from PIL import Image, ImageSequence
@@ -391,6 +392,7 @@ class PDFHandler:
         new_doc.write('  white-space: nowrap;\n')
         # font aspect: 0.6
         new_doc.write('  font-family: monospace;\n')
+        # new_doc.write('  outline: solid 1px red;\n') # debug
         new_doc.write('}\n')
         new_doc.write('</style>\n')
         new_doc.write('</head>\n')
@@ -432,10 +434,18 @@ class PDFHandler:
                     del img_url
                     new_doc.write(f'<div class="page" style="{page_style}">\n')
                     del page_style
+                    prev_rect_coords = None
                     for rect_coords, text in pages_data.get(page_num, []):
+                        if rect_coords[1] == rect_coords[3] == 1:
+                            # last line has zero height
+                            if prev_rect_coords:
+                                rect_coords[1] = prev_rect_coords[3]
+                            else:
+                                rect_coords[1] = 0.9
                         self._draw_invisible_text_html(
                             new_page, rect_coords, text, width, height
                         )
+                        prev_rect_coords = rect_coords
                     new_doc.write(f'</div>\n')
                 return
                 # TODO remove
@@ -495,6 +505,7 @@ class PDFHandler:
                 page,
                 fallback_rect,
                 text,
+                # attrs=dict(rect=rect_coords), # debug
                 # fontsize=6,
                 # fontname="helv",
                 # render_mode=3,
@@ -527,6 +538,7 @@ class PDFHandler:
                 page,
                 line_rect,
                 line,
+                # attrs=dict(rect=rect_coords), # debug
             )
             # PDFHandler._draw_invisible_text(
             #     page,
@@ -629,12 +641,17 @@ class PDFHandler:
         )
 
 
+def try_make_int(n):
+    if int(n) == n:
+        return int(n)
+    return n
 
 
 def _page_insert_textbox_html(
         page,
         rect,
         text,
+        attrs=None,
         # fontsize=6,
         # fontname="helv",
         # render_mode=3,
@@ -647,13 +664,23 @@ def _page_insert_textbox_html(
     font_rel_width = 0.6 # monospace # width / height
     char_width = width / len(text)
     char_height = char_width / font_rel_width
-    font_size = min(height, char_height)
+    # font_size = min(height, char_height)
+    font_size = height
+    raw_width = len(text) * font_size * font_rel_width
+    letter_spacing = (width - raw_width) / len(text)
     line_style = (
-        f"left:{x0}px;" +
-        f"top:{y0}px;" +
-        f"width:{width}px;" +
-        f"height:{height}px;" +
-        f"font-size:{font_size}px;" +
+        f"left:{try_make_int(x0)}px;" +
+        f"top:{try_make_int(y0)}px;" +
+        f"width:{try_make_int(width)}px;" +
+        f"height:{try_make_int(height)}px;" +
+        f"font-size:{try_make_int(font_size)}px;" +
+        f"letter-spacing:{try_make_int(letter_spacing)}px;" +
         ""
     )
-    page.write(f'<span class="line" style="{line_style}">{text}</span>\n')
+    attrs_str = ""
+    if attrs is None:
+        attrs = dict()
+    for key, val in attrs.items():
+        val_str = json.dumps(val, separators=(',', ':'))
+        attrs_str += f' {key}={val_str!r}'
+    page.write(f'<span class="line" style="{line_style}"{attrs_str}>{text}</span>\n')

--- a/src/pdf_ocr/core/pdf.py
+++ b/src/pdf_ocr/core/pdf.py
@@ -394,6 +394,12 @@ class PDFHandler:
         new_doc.write('  font-family: monospace;\n')
         # new_doc.write('  outline: solid 1px red;\n') # debug
         new_doc.write('}\n')
+        # invert colors in darkmode
+        new_doc.write('@media (prefers-color-scheme: dark) {\n')
+        new_doc.write('  div.page {\n')
+        new_doc.write('    filter: invert() hue-rotate(180deg);\n')
+        new_doc.write('  }\n')
+        new_doc.write('}\n')
         new_doc.write('</style>\n')
         new_doc.write('</head>\n')
         new_doc.write('<body>\n')

--- a/src/pdf_ocr/core/pdf.py
+++ b/src/pdf_ocr/core/pdf.py
@@ -652,6 +652,7 @@ def _page_insert_textbox_html(
         rect,
         text,
         attrs=None,
+        use_letter_spacing=False,
         # fontsize=6,
         # fontname="helv",
         # render_mode=3,
@@ -662,21 +663,27 @@ def _page_insert_textbox_html(
     width = x1 - x0
     height = y1 - y0
     font_rel_width = 0.6 # monospace # width / height
-    char_width = width / len(text)
-    char_height = char_width / font_rel_width
-    # font_size = min(height, char_height)
-    font_size = height
-    raw_width = len(text) * font_size * font_rel_width
-    letter_spacing = (width - raw_width) / len(text)
+    if use_letter_spacing:
+        # negative letter-spacing can make the text hard to read
+        font_size = height
+        raw_width = len(text) * font_size * font_rel_width
+        letter_spacing = (width - raw_width) / len(text)
+    else:
+        char_width = width / len(text)
+        char_height = char_width / font_rel_width
+        font_size = min(height, char_height)
     line_style = (
         f"left:{try_make_int(x0)}px;" +
         f"top:{try_make_int(y0)}px;" +
         f"width:{try_make_int(width)}px;" +
-        f"height:{try_make_int(height)}px;" +
         f"font-size:{try_make_int(font_size)}px;" +
-        f"letter-spacing:{try_make_int(letter_spacing)}px;" +
         ""
     )
+    if use_letter_spacing:
+        line_style += f"letter-spacing:{try_make_int(letter_spacing)}px;"
+    elif height != font_size:
+        # preserve height
+        line_style += f"height:{try_make_int(height)}px;"
     attrs_str = ""
     if attrs is None:
         attrs = dict()


### PR DESCRIPTION
fix https://github.com/ahnafnafee/local-llm-pdf-ocr/issues/6#issuecomment-4341354245

example output with grounded olmocr
[2026-03-26.22-00.olmocr.html](https://milahu.github.io/alchi-journal/img/2026-03/2026-03-26.22-00.olmocr.html)

this is a minimal-diff patch, hooking into the PDF writer module
ideally this should be a separate module in `src/pdf_ocr/core/html.py`
but that requires patching some call sites
for examlpe by replacing the `pdf_handler` kwarg
with `input_handler` and `output_handler`
or `src_handler` and `dst_handler`

use [letter-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/letter-spacing) to stretch text to line width
this also works on `span` elements with `display:inline`
`transform:scaleX` would require `display:block`
