### PR TITLE
fix: error on model mismatch instead of silent fallback (closes #7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ uv run main.py input.pdf --dense-threshold 40                 # auto-mode kicks 
 uv run main.py input.pdf --api-base http://localhost:11434/v1 --model glm-ocr:latest --max-image-dim 640   # Ollama + GLM-OCR
 uv run main.py input.pdf --grounded --model qwen/qwen3-vl-8b  # grounded path: bbox-native VLM, no Surya
 uv run main.py photo.avif                                     # AVIF input (native via Pillow ≥11.3)
+uv run main.py input.pdf --no-verify-model                    # skip pre-flight model check (Ollama / non-/v1/models servers)
 uv run main.py input.pdf -v                                   # verbose debug logging
 uv run uvicorn server:app --reload --port 8000                # web UI at http://localhost:8000
 ```
@@ -55,7 +56,12 @@ LLM endpoint is read from `.env` (or CLI overrides `--api-base` / `--model`). LM
 LLM_API_BASE=http://localhost:1234/v1
 LLM_MODEL=allenai/olmocr-2-7b
 OCR_CONCURRENCY=3          # server.py — async LLM concurrency
+OCR_VERIFY_MODEL=0         # server.py — opt out of pre-flight model check (default: on)
 ```
+
+### Pre-flight model verification (issue #7)
+
+Both entry points hit `GET /v1/models` before any OCR work to confirm the configured model is loaded, raising `ModelNotLoadedError` (subclass of `LLMCallError`) on mismatch. LM Studio otherwise silently falls back to whatever model is loaded, producing subtly wrong OCR with no error to flag the mismatch. Implementation lives on the backends — `OCRProcessor.ensure_model_loaded()` and `PromptedGroundedOCR.ensure_model_loaded()` — both reusing the same `_list_loaded_model_ids` / `_format_model_not_loaded` helpers in `core/ocr.py`. Disable per-call with CLI `--no-verify-model` or env `OCR_VERIFY_MODEL=0` (server only).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ graph TD
 
 1.  **Python 3.10+**
 2.  **A local OpenAI-compatible LLM server**. Any of:
-    -   **[LM Studio](https://lmstudio.ai)** — recommended default. Load `allenai/olmocr-2-7b` (hybrid path) or `qwen/qwen3-vl-8b` / `qwen/qwen2.5-vl-7b` (grounded path). Start the local server (default port `1234`).
+    -   **[LM Studio](https://lmstudio.ai)** — recommended default. Load `allenai/olmocr-2-7b` (hybrid path) or `qwen/qwen3-vl-8b` / `qwen/qwen2.5-vl-7b` (grounded path). Start the local server (default port `1234`). The CLI runs a pre-flight check that the requested model is actually loaded — LM Studio otherwise silently falls back to whatever model is loaded, producing subtly wrong OCR (issue #7). Use `--no-verify-model` to skip on servers that don't expose `/v1/models`.
     -   **[Ollama](https://ollama.com)** — pull `glm-ocr:latest` (requires `--max-image-dim 640`) or any vision model. Served at `http://localhost:11434/v1`.
     -   **vLLM / SGLang / any OpenAI-compatible endpoint**.
 
@@ -169,6 +169,7 @@ uv run local-llm-pdf-ocr input.pdf output_ocr.pdf
 | `--grounded`              | Use a bbox-native VLM that returns text + coordinates in one call (skips Surya, DP, refine). Requires a grounding-capable model via `--model`. |
 | `--api-base <url>`        | Override LLM API base URL                                             |
 | `--model <name>`          | Override LLM model name                                               |
+| `--no-verify-model`       | Skip the pre-flight check that `--model` is loaded on the server (issue #7). LM Studio otherwise silently falls back to whatever model is loaded; we hit `GET /v1/models` and fail fast on mismatch. Use on Ollama / vLLM (which auto-load), or any server that doesn't implement `/v1/models`. |
 
 **Examples**:
 

--- a/src/pdf_ocr/cli.py
+++ b/src/pdf_ocr/cli.py
@@ -85,7 +85,16 @@ Examples:
     )
     parser.add_argument("--api-base", help="Override LLM API base URL")
     parser.add_argument("--model", help="Override LLM model name")
-    parser.set_defaults(refine=True)
+    parser.add_argument(
+        "--no-verify-model", dest="verify_model", action="store_false",
+        help="Skip the pre-flight check that --model is loaded on the server. "
+             "By default we hit GET /v1/models and fail fast if the requested "
+             "model is missing — LM Studio otherwise silently falls back to "
+             "whatever model is loaded, producing subtly wrong OCR (issue #7). "
+             "Use this if your server doesn't implement /v1/models, or on "
+             "Ollama / vLLM (which auto-load on demand).",
+    )
+    parser.set_defaults(refine=True, verify_model=True)
     return parser
 
 
@@ -134,6 +143,21 @@ async def run(args: argparse.Namespace, console: Console) -> None:
         )
 
     output_path = resolve_output_path(args.input_pdf, args.output_pdf)
+
+    if args.verify_model:
+        # Fail fast on model mismatch BEFORE we pay for PDF rasterization
+        # or Surya detection. LM Studio's silent fallback (issue #7) is
+        # otherwise invisible until the user notices wrong OCR output.
+        # Print the error here too — main()'s outer except swallows the
+        # message and only exits 1, which would leave the user staring
+        # at a silent failure.
+        backend = pipeline.grounded_backend if args.grounded else pipeline.ocr_processor
+        try:
+            await backend.ensure_model_loaded()
+        except Exception as e:
+            console.print(f"[bold red]Error:[/bold red] {e}")
+            raise
+
     console.print(f"[bold cyan]Processing '{args.input_pdf}'...[/bold cyan]")
 
     progress = Progress(

--- a/src/pdf_ocr/core/grounded.py
+++ b/src/pdf_ocr/core/grounded.py
@@ -367,6 +367,31 @@ class PromptedGroundedOCR:
         self.max_tokens = max_tokens
         self.concurrency = concurrency
 
+    async def ensure_model_loaded(self) -> None:
+        """Pre-flight check that ``self.model`` is loaded on the server.
+
+        Mirrors :meth:`OCRProcessor.ensure_model_loaded` so users on
+        ``--grounded`` get the same fail-fast safety net. The grounded
+        path is in fact the path that originally surfaced this bug
+        (issue #7) — the user had OlmOCR loaded but requested Qwen3-VL,
+        and LM Studio silently served bad OCR from the wrong model.
+        """
+        from openai import AsyncOpenAI
+
+        from pdf_ocr.core.ocr import (
+            ModelNotLoadedError,
+            _format_model_not_loaded,
+            _list_loaded_model_ids,
+            _model_in_loaded,
+        )
+
+        client = AsyncOpenAI(base_url=self.api_base, api_key=self.api_key)
+        loaded = await _list_loaded_model_ids(client, self.api_base)
+        if not _model_in_loaded(self.model, loaded):
+            raise ModelNotLoadedError(
+                _format_model_not_loaded(self.api_base, self.model, loaded)
+            )
+
     async def ocr_document(
         self,
         pdf_path: str,

--- a/src/pdf_ocr/core/ocr.py
+++ b/src/pdf_ocr/core/ocr.py
@@ -24,6 +24,19 @@ class LLMCallError(RuntimeError):
     """
 
 
+class ModelNotLoadedError(LLMCallError):
+    """Raised when the requested model is not loaded on the LLM server.
+
+    LM Studio silently falls back to whatever model is currently loaded
+    when an OpenAI-compat client requests an unavailable model ID — so a
+    typo in --model or a forgotten model swap produces subtly wrong OCR
+    output with no surface error. This exception is raised by
+    :meth:`OCRProcessor.ensure_model_loaded` (and the grounded equivalent)
+    *before* any OCR work starts so the user sees the mismatch immediately
+    instead of debugging strange output later.
+    """
+
+
 # Canonical OlmOCR-2 prompt (the model was RL-trained on this exact string).
 # Source: github.com/allenai/olmocr olmocr/prompts/prompts.py
 # :func:`build_no_anchoring_v4_yaml_prompt`.
@@ -100,6 +113,25 @@ class OCRProcessor:
         self.api_base = api_base or os.getenv("LLM_API_BASE", "http://localhost:1234/v1")
         self.model = model or os.getenv("LLM_MODEL", "allenai/olmocr-2-7b")
         self.client = AsyncOpenAI(base_url=self.api_base, api_key="lm-studio")
+
+    async def ensure_model_loaded(self) -> None:
+        """Pre-flight check that ``self.model`` is loaded on the server.
+
+        Hits ``GET /v1/models`` via the OpenAI SDK and verifies the
+        configured model ID appears in the loaded list (case-insensitive).
+        Raises :class:`ModelNotLoadedError` on mismatch with a message
+        that names what's loaded and how to fix it. Wraps any underlying
+        transport / auth failure in :class:`LLMCallError`.
+
+        Why we do this: see :class:`ModelNotLoadedError`. Cheap call (one
+        GET, no inference); call once at pipeline startup before paying
+        for image conversion or detection.
+        """
+        loaded = await _list_loaded_model_ids(self.client, self.api_base)
+        if not _model_in_loaded(self.model, loaded):
+            raise ModelNotLoadedError(
+                _format_model_not_loaded(self.api_base, self.model, loaded)
+            )
 
     async def perform_ocr(self, image_base64: str) -> list[str]:
         """
@@ -222,6 +254,50 @@ def _strip_runaway_repetition(lines: list[str], max_repeat: int = 20) -> list[st
             truncated, worst[0][:60], worst[1],
         )
     return out
+
+
+async def _list_loaded_model_ids(client: AsyncOpenAI, api_base: str) -> list[str]:
+    """Return model IDs loaded on an OpenAI-compatible server.
+
+    Uses the SDK's ``client.models.list()`` (hits ``GET /v1/models``).
+    Wraps any transport / auth / response-shape failure in
+    :class:`LLMCallError` with the same diagnostic format ``_chat`` uses
+    so the caller sees a consistent error message style across the
+    pipeline's LLM-facing surfaces.
+    """
+    try:
+        page = await client.models.list()
+    except Exception as e:
+        raise LLMCallError(
+            f"Could not list models on {api_base}: "
+            f"{type(e).__name__}: {e}\n"
+            f"  - Is your local LLM server (LM Studio / Ollama / vLLM) running at "
+            f"{api_base}?\n"
+            f"  - Does it expose GET /v1/models? (Most do; some custom servers "
+            f"don't — pass --no-verify-model to skip this check.)"
+        ) from e
+    return [m.id for m in page.data]
+
+
+def _model_in_loaded(model: str, loaded: list[str]) -> bool:
+    target = model.lower()
+    return any(m.lower() == target for m in loaded)
+
+
+def _format_model_not_loaded(api_base: str, model: str, loaded: list[str]) -> str:
+    listing = "\n    ".join(loaded) if loaded else "(none)"
+    return (
+        f"Model {model!r} is not loaded on {api_base}.\n"
+        f"  Loaded models:\n    {listing}\n"
+        f"  Fix:\n"
+        f"    - Load {model!r} in LM Studio (Models -> search -> Load), then retry.\n"
+        f"    - Or pass --model with one of the loaded model IDs above.\n"
+        f"    - Or pass --no-verify-model to skip this check "
+        f"(e.g. on Ollama / vLLM, which auto-load on demand).\n"
+        f"  Why this matters: LM Studio silently falls back to whatever model is "
+        f"loaded when the requested one is missing, producing subtly wrong OCR "
+        f"results with no error. (issue #7)"
+    )
 
 
 def _strip_yaml_front_matter(text: str) -> str:

--- a/src/pdf_ocr/server.py
+++ b/src/pdf_ocr/server.py
@@ -99,6 +99,11 @@ async def process_pdf(file: UploadFile = File(...), client_id: str = Form(...)):
         )
         concurrency = int(os.getenv("OCR_CONCURRENCY", 3))
 
+        # Fail fast on model mismatch (issue #7). Set OCR_VERIFY_MODEL=0 to
+        # skip if your server doesn't expose /v1/models.
+        if os.getenv("OCR_VERIFY_MODEL", "1") != "0":
+            await pipeline.ocr_processor.ensure_model_loaded()
+
         async def on_progress(stage, current, total, message):
             await manager.send_progress(client_id, message, stage_to_percent(stage, current, total))
 

--- a/tests/test_grounded.py
+++ b/tests/test_grounded.py
@@ -18,13 +18,17 @@ from pathlib import Path
 import fitz
 import pytest
 
+from types import SimpleNamespace
+
 from pdf_ocr.core.grounded import (
     GroundedBlock,
     GroundedResponse,
+    PromptedGroundedOCR,
     _parse_grounded_json,
     parse_glm_layout_details,
     parse_zai_response,
 )
+from pdf_ocr.core.ocr import LLMCallError, ModelNotLoadedError
 from pdf_ocr.core.pdf import PDFHandler
 from pdf_ocr.pipeline import OCRPipeline
 
@@ -421,3 +425,57 @@ class TestPromptedGroundedParser:
         raw = 'Here is the result:\n[{"bbox_2d":[0,0,10,10],"content":"x"}]'
         blocks = _parse_grounded_json(raw, page_idx=0, img_w=10, img_h=10)
         assert len(blocks) == 1
+
+
+class TestPromptedGroundedEnsureModelLoaded:
+    """Pre-flight model verification for the grounded path. Issue #7 was
+    actually filed against the grounded path specifically — user had
+    OlmOCR loaded but requested Qwen3-VL, and got OlmOCR's bad grounded
+    output instead of Qwen3-VL's good output."""
+
+    def _patch_openai(self, monkeypatch, model_ids=None, raise_exc=None):
+        async def _list():
+            if raise_exc is not None:
+                raise raise_exc
+            return SimpleNamespace(
+                data=[SimpleNamespace(id=m) for m in (model_ids or [])]
+            )
+
+        fake_client = SimpleNamespace(
+            models=SimpleNamespace(list=_list)
+        )
+
+        def _fake_async_openai(*args, **kwargs):
+            return fake_client
+
+        # ensure_model_loaded does `from openai import AsyncOpenAI` inside,
+        # so we patch the source module's attribute.
+        monkeypatch.setattr("openai.AsyncOpenAI", _fake_async_openai)
+        return fake_client
+
+    def test_passes_when_model_loaded(self, monkeypatch):
+        self._patch_openai(monkeypatch, model_ids=["qwen/qwen3-vl-8b"])
+        backend = PromptedGroundedOCR(
+            api_base="http://localhost:1234/v1",
+            model="qwen/qwen3-vl-8b",
+        )
+        asyncio.run(backend.ensure_model_loaded())  # no raise
+
+    def test_raises_on_mismatch_with_helpful_message(self, monkeypatch):
+        # The exact issue #7 scenario: requested grounded-capable Qwen3-VL,
+        # but LM Studio has the OlmOCR text-only model loaded.
+        self._patch_openai(monkeypatch, model_ids=["allenai_olmocr-2-7b-1025"])
+        backend = PromptedGroundedOCR(
+            api_base="http://localhost:1234/v1",
+            model="qwen/qwen3-vl-8b",
+        )
+        with pytest.raises(ModelNotLoadedError) as exc_info:
+            asyncio.run(backend.ensure_model_loaded())
+        msg = str(exc_info.value)
+        assert "qwen/qwen3-vl-8b" in msg
+        assert "allenai_olmocr-2-7b-1025" in msg
+        assert "--no-verify-model" in msg
+
+    def test_subclass_of_llm_call_error(self):
+        # Catchable via the same except-clause as other LLM failures.
+        assert issubclass(ModelNotLoadedError, LLMCallError)

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
 from pdf_ocr.core.ocr import (
     CROP_PROMPT,
     OLMOCR_PAGE_PROMPT,
+    LLMCallError,
+    ModelNotLoadedError,
+    OCRProcessor,
     _strip_runaway_repetition,
     _strip_yaml_front_matter,
 )
@@ -161,6 +169,111 @@ class TestHallucinationFilter:
             assert asyncio.run(ocr.perform_ocr_on_crop("ignored")) == "", (
                 f"variant {variant!r} should be dropped"
             )
+
+
+def _fake_models_client(model_ids=None, raise_exc=None):
+    """Build a stand-in for AsyncOpenAI exposing only `client.models.list()`.
+
+    Mirrors the SDK shape: ``await client.models.list()`` returns an object
+    with a ``.data`` attribute that's a list of objects each with an ``.id``.
+    """
+    async def _list():
+        if raise_exc is not None:
+            raise raise_exc
+        return SimpleNamespace(
+            data=[SimpleNamespace(id=m) for m in (model_ids or [])]
+        )
+    return SimpleNamespace(models=SimpleNamespace(list=_list))
+
+
+def _make_ocr_with_fake_client(model: str, fake_client) -> OCRProcessor:
+    """Construct an OCRProcessor without going through __init__ (which
+    would create a real AsyncOpenAI client). Same trick as
+    TestHallucinationFilter above."""
+    ocr = OCRProcessor.__new__(OCRProcessor)
+    ocr.api_base = "http://localhost:1234/v1"
+    ocr.model = model
+    ocr.client = fake_client
+    return ocr
+
+
+class TestEnsureModelLoaded:
+    """Pre-flight check that the requested model is loaded on the LLM
+    server. LM Studio silently falls back to whatever is loaded on
+    mismatch, so without this check users get bad OCR with no error
+    (issue #7)."""
+
+    def test_passes_when_model_in_loaded_list(self):
+        ocr = _make_ocr_with_fake_client(
+            "qwen/qwen3-vl-8b",
+            _fake_models_client(["qwen/qwen3-vl-8b", "allenai/olmocr-2-7b"]),
+        )
+        # No raise — exact match found.
+        asyncio.run(ocr.ensure_model_loaded())
+
+    def test_passes_case_insensitive(self):
+        # User passes "Qwen/Qwen3-VL-8B" but server returns "qwen/qwen3-vl-8b"
+        # — same model file, just shifted case. Don't make the user fight casing.
+        ocr = _make_ocr_with_fake_client(
+            "Qwen/Qwen3-VL-8B",
+            _fake_models_client(["qwen/qwen3-vl-8b"]),
+        )
+        asyncio.run(ocr.ensure_model_loaded())
+
+    def test_raises_with_helpful_message_on_mismatch(self):
+        # The exact scenario from the issue: user passed qwen3-vl-8b but
+        # LM Studio has olmocr loaded. Must surface this loudly.
+        ocr = _make_ocr_with_fake_client(
+            "qwen/qwen3-vl-8b",
+            _fake_models_client(["allenai_olmocr-2-7b-1025"]),
+        )
+        with pytest.raises(ModelNotLoadedError) as exc_info:
+            asyncio.run(ocr.ensure_model_loaded())
+
+        msg = str(exc_info.value)
+        # Must name the requested model (so the user knows what they asked for)…
+        assert "qwen/qwen3-vl-8b" in msg
+        # …and what the server actually has loaded (so they can either
+        # change --model or load the right one)…
+        assert "allenai_olmocr-2-7b-1025" in msg
+        # …and tell them about the escape hatch for non-LM-Studio servers.
+        assert "--no-verify-model" in msg
+        # …and explain WHY this matters (silent fallback) so they don't
+        # treat the check as a bug to disable and forget.
+        assert "silently" in msg.lower() or "fallback" in msg.lower()
+
+    def test_raises_with_none_listing_when_no_models_loaded(self):
+        # LM Studio with no model loaded at all. The error message
+        # should still be informative, not say "Loaded models: " followed
+        # by nothing (which reads like a parse error).
+        ocr = _make_ocr_with_fake_client(
+            "qwen/qwen3-vl-8b",
+            _fake_models_client([]),
+        )
+        with pytest.raises(ModelNotLoadedError) as exc_info:
+            asyncio.run(ocr.ensure_model_loaded())
+        assert "(none)" in str(exc_info.value)
+
+    def test_subclass_of_llm_call_error(self):
+        # Existing callers of LLMCallError (e.g. CLI's generic
+        # except-and-print path) must continue to catch this without
+        # special-casing.
+        assert issubclass(ModelNotLoadedError, LLMCallError)
+
+    def test_server_failure_wrapped_as_llm_call_error(self):
+        # If /v1/models fails (server down, wrong endpoint, auth error)
+        # surface a single-paragraph LLMCallError rather than the bare
+        # ConnectionError stack — match the diagnostic style of _chat.
+        ocr = _make_ocr_with_fake_client(
+            "qwen/qwen3-vl-8b",
+            _fake_models_client(raise_exc=ConnectionError("connection refused")),
+        )
+        with pytest.raises(LLMCallError) as exc_info:
+            asyncio.run(ocr.ensure_model_loaded())
+        # Must point the user at the server (where to look) and at the
+        # opt-out flag (how to bypass for non-conforming servers).
+        assert "http://localhost:1234/v1" in str(exc_info.value)
+        assert "--no-verify-model" in str(exc_info.value)
 
 
 class TestPromptConstants:


### PR DESCRIPTION
## Summary

- LM Studio silently falls back to the loaded model when the OpenAI-compat client requests an unavailable model ID, so a typo in `--model` or a forgotten model swap produces subtly wrong OCR with no error (issue #7).
- Add a pre-flight `GET /v1/models` check that raises `ModelNotLoadedError` on mismatch, listing the loaded models and pointing the user at three fixes (load it, change `--model`, or pass `--no-verify-model`).
- Default-on for both backends; `--no-verify-model` (CLI) / `OCR_VERIFY_MODEL=0` (server) opts out for Ollama / vLLM / non-conforming servers.

## Test plan

- [x] 9 new unit tests in `tests/test_ocr.py` and `tests/test_grounded.py` cover happy path, case-insensitive match, mismatch with helpful message, empty-list edge case, server-failure wrapping, and `LLMCallError` subclass invariant.
- [x] Full fast tier passes: `uv run pytest -m "not slow"` → 175/175.
- [x] Live smoke test against LM Studio (port 3002):
    - [x] Bogus `--model` on hybrid path → `ModelNotLoadedError` with full message, exit 1.
    - [x] Bogus `--model qwen/qwen3-vl-8b` on `--grounded` path (original issue scenario, server has `qwen3-vl-4b` not `8b`) → errors, exit 1.
    - [x] Same as above with `--no-verify-model` → bypasses check, falls through to LM Studio (silent fallback, original bug behavior preserved as opt-in).
    - [x] Correct `--model qwen/qwen3-vl-4b` → verification passes, OCR runs to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)