### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "local-llm-pdf-ocr"
-version = "0.1.0"
+version = "0.2.0"
 description = "Transform scanned and written documents into fully searchable, selectable PDFs using the power of Local LLM Vision"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pdf_ocr/__init__.py
+++ b/src/pdf_ocr/__init__.py
@@ -5,7 +5,7 @@ Converts scanned PDFs into searchable documents using local vision LLMs
 for text extraction and Surya for layout detection.
 """
 
-__version__ = "1.0.0"
+__version__ = "0.2.0"
 
 from pdf_ocr.core.aligner import HybridAligner
 from pdf_ocr.core.grounded import (

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "local-llm-pdf-ocr"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "jiwer" },


### PR DESCRIPTION
## Summary
- Bumps `version` to 0.2.0 in pyproject.toml — merging this fires the release workflow (build wheel/sdist, update README pin, tag `v0.2.0`, publish the GitHub release with auto-generated notes).
- Aligns `pdf_ocr.__version__` (had drifted to "1.0.0") and the project's own entry in `uv.lock`.

Headline changes since v0.1.0: photo preprocessing/rectification, exact quad overlays + rectified crops + confidence plumbing (#16), and the dense small-print duplication fix (#17/#18).

## Test plan
- [x] `uv run pytest -m "not slow"` — 420 passed
- [x] Release workflow validates the version format and builds the wheel before tagging; it skips if the tag already exists